### PR TITLE
Small echo_config placeholder to fix parsing issue

### DIFF
--- a/scripts/logs.sh
+++ b/scripts/logs.sh
@@ -22,4 +22,9 @@ echo_logo() {
 
 echo_config() {
 
+  printf "\n"
+  echo "===================="
+  echo "  Configurations"
+  echo "===================="
+
 }


### PR DESCRIPTION
Before:
```
$ ./main.sh 
./scripts/logs.sh: line 25: syntax error near unexpected token `}'
```

After:
```
$ ./main.sh 

====================
  .**.         +#- 
 :*=-#=      -*=-#= 
:%%  +%*    -%%  *%=
-%%  -%%.   *%*  *%+
-%%  .%%-   %%-  *%+
-%%.  #%+  :%%.  #%+
-%%.  =%#  =%#   *%+
-%%    -*--*=    *%+
      MiniMina
 Mina Local Network
====================

```