### PR TITLE
4 - Update github workflow runner

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,6 +15,7 @@ jobs:
     runs-on: minafoundation-default-runners
 
     steps:
+
     - name: 📥 Checkout
       uses: actions/checkout@v3
 


### PR DESCRIPTION
Please do not review this PR yet.
`minafoundation-default-runners` are missing essential packages