### PR TITLE
Fill info in Cargo.Toml required by cargo deb

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,11 @@
 name = "minimina"
 version = "0.1.0"
 edition = "2021"
+license = "LICENSE"
+description = """\
+MiniMina is a command line tool aimed at providing the capability \
+to spin up Mina networks locally on a user's computer."""
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 clap = { version = "4.4.6", features = ["derive"] }
@@ -19,3 +22,11 @@ reqwest = { version = "0.11.20", features = ["blocking"] }
 url = "2.4.1"
 tempdir = "0.3.7"
 
+[package.metadata.deb]
+maintainer = "Piotr Stachyra <piotr.stachyra@minaprotocol.com>"
+copyright = "2023, Piotr Stachyra <piotr.stachyra@minaprotocol.com"
+depends = "$auto"
+assets = [
+    ["target/release/minimina", "usr/bin/", "755"],
+    ["README.md", "usr/share/doc/minimina/README", "644"],
+]


### PR DESCRIPTION
In order to be able to upload minimina on debian repository, we can use cargo-deb tool. Adding data to Cargo.toml which are required by tool.

After this change we can create deb package by command: 
`cargo deb command`