### PR TITLE
Start filtered logs via gql on node start

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -136,6 +136,10 @@ pub struct StartNodeCommandArgs {
     #[clap(short = 'a', long, default_value_t = false)]
     pub import_accounts: bool,
 
+    /// Start node with GraphQL filtered logs enabled
+    #[clap(short = 'g', long, default_value_t = false)]
+    pub graphql_filtered_logs: bool,
+
     #[clap(flatten)]
     pub node_args: NodeCommandArgs,
 }

--- a/src/directory_manager.rs
+++ b/src/directory_manager.rs
@@ -25,6 +25,7 @@ use std::{
 pub const NETWORK_KEYPAIRS: &str = "network-keypairs";
 const LIBP2P_KEYPAIRS: &str = "libp2p-keypairs";
 
+#[derive(Clone)]
 pub struct DirectoryManager {
     pub base_path: PathBuf,
     pub subdirectories: [&'static str; 2],

--- a/src/docker/manager.rs
+++ b/src/docker/manager.rs
@@ -295,6 +295,25 @@ impl DockerManager {
         self.run_docker_compose(cmd)
     }
 
+    pub fn compose_client_status(
+        &self,
+        node_id: &str,
+        network_id: &str,
+        client_port: u16,
+    ) -> Result<Output> {
+        let service = format!("{node_id}-{network_id}");
+        let cmd = &[
+            "exec",
+            &service,
+            "mina",
+            "client",
+            "status",
+            "-daemon-port",
+            &client_port.to_string(),
+        ];
+        self.run_docker_compose(cmd)
+    }
+
     /// Filter container by service name
     /// returns Option<ContainerInfo>
     pub fn filter_container_by_name(

--- a/src/docker/manager.rs
+++ b/src/docker/manager.rs
@@ -295,6 +295,7 @@ impl DockerManager {
         self.run_docker_compose(cmd)
     }
 
+    #[allow(dead_code)]
     pub fn compose_client_status(
         &self,
         node_id: &str,

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -1,0 +1,170 @@
+use log::info;
+
+use crate::{directory_manager::DirectoryManager, exit_with, output::network, TIMEOUT_IN_SECS};
+use std::{self, io::Result};
+
+pub struct GraphQl {
+    directory_manager: DirectoryManager,
+}
+
+impl GraphQl {
+    pub fn new(directory_manager: DirectoryManager) -> Self {
+        Self { directory_manager }
+    }
+
+    pub fn get_endpoint(&self, node_id: &str, network_id: &str) -> Option<String> {
+        let nodes = self.directory_manager.get_network_info(network_id);
+        match nodes {
+            Ok(nodes) => {
+                let info = serde_json::from_str::<network::Create>(&nodes).unwrap();
+                let node = info.nodes.get(node_id)?;
+                let graphql_endpoint = node.graphql_uri.as_ref()?;
+                Some(graphql_endpoint.to_string())
+            }
+            Err(_) => None,
+        }
+    }
+
+    /// Waits for graphql server to start
+    pub fn wait_for_server(&self, gql_ep: &str) -> Result<()> {
+        let mut retries = 0;
+        let mut graphql_running = false;
+        info!("Waiting for graphql to start '{gql_ep}'");
+        let client = reqwest::blocking::Client::new();
+
+        while !graphql_running && retries < TIMEOUT_IN_SECS {
+            let response = client
+                .get(gql_ep)
+                .header("Content-Type", "application/json")
+                .send();
+
+            if response.is_ok() {
+                graphql_running = true;
+            } else {
+                retries += 1;
+                std::thread::sleep(std::time::Duration::from_secs(1));
+            }
+        }
+        if !graphql_running {
+            return exit_with(format!(
+                "Failed to start graphql '{gql_ep}' within {TIMEOUT_IN_SECS}s",
+            ));
+        }
+        Ok(())
+    }
+
+    /// Requests filtered logs via graphql
+    pub fn request_filtered_logs(&self, gql_ep: &str) -> Result<()> {
+        // Filtered logs request payload
+        let query = r#"{
+        "query": "mutation MyMutation 
+                    { startFilteredLog(filter: [\"21ccae8c619bc2666474085272d5fe1d\", 
+                                                \"ef1182dc30f3e0aa9f6bf11c0ab90ba6\",
+                                                \"64e2d3e86c37c09b15efdaf7470ce879\",
+                                                \"db06cb5030f39e86e84b30d033f3bc5c\", 
+                                                \"60076de624bf0c5fc0843b875001cf84\", 
+                                                \"27953f46376ba8abc0c61400e2c38f8b\", 
+                                                \"b4b5f5b1d1a0c457cbd13a35d1c8b57b\", 
+                                                \"0fc65f5594c5e9ee0b6f0ddde747c758\", 
+                                                \"b5a89d6d616a35fb6f73d1eaad6b2dbd\", 
+                                                \"1c4150aa7058a3058c4d20ae90ff7ec3\", 
+                                                \"f7254e63ad51092a0bd3078580ef9ce3\", 
+                                                \"74a81f1e2f8d548e4550faa136c68160\", 
+                                                \"30fe76cee159ea215fc05549e861501e\"]) }"
+    }"#;
+
+        let client = reqwest::blocking::Client::new();
+        info!("Sending request to: {gql_ep}");
+        let response = client
+            .post(gql_ep)
+            .header("Content-Type", "application/json")
+            .body(query)
+            .send();
+        if let Err(e) = response {
+            return exit_with(format!(
+                "Failed to send request to graphql endpoint '{gql_ep}': {e}",
+            ));
+        }
+
+        // Read the response body
+        let response_body = response.unwrap().text();
+        if let Err(e) = response_body {
+            return exit_with(format!(
+                "Failed to read response body from graphql endpoint '{gql_ep}': {e}",
+            ));
+        }
+        info!("Response body: {}", response_body.unwrap());
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn test_get_endpoint() {
+        use super::*;
+        use crate::directory_manager::DirectoryManager;
+        use std::fs::File;
+        use std::io::Write;
+        use std::path::PathBuf;
+        use tempdir::TempDir;
+
+        let tempdir = TempDir::new("test_get_endpoint").expect("Cannot create temporary directory");
+        let network_info_str = "{
+            \"network_id\": \"test_deserialize\",
+            \"nodes\": {
+                \"mina-archive\": {
+                    \"graphql_uri\": null,
+                    \"private_key\": null,
+                    \"node_type\": \"Archive_node\"
+                },
+                \"mina-snark-coordinator\": {
+                    \"graphql_uri\": \"http://localhost:7001/graphql\",
+                    \"private_key\": null,
+                    \"node_type\": \"Snark_coordinator\"
+                },
+                \"mina-bp-1\": {
+                    \"graphql_uri\": \"http://localhost:4001/graphql\",
+                    \"private_key\": null,
+                    \"node_type\": \"Block_producer\"
+                },
+                \"mina-bp-2\": {
+                    \"graphql_uri\": \"http://localhost:4006/graphql\",
+                    \"private_key\": null,
+                    \"node_type\": \"Block_producer\"
+                },
+                \"mina-seed-1\": {
+                    \"graphql_uri\": \"http://localhost:3101/graphql\",
+                    \"private_key\": null,
+                    \"node_type\": \"Seed_node\"
+                },
+                \"mina-snark-worker-1\": {
+                    \"graphql_uri\": null,
+                    \"private_key\": null,
+                    \"node_type\": \"Snark_worker\"
+                }
+            }
+        }";
+        let base_path = PathBuf::from(tempdir.path());
+        let network_id = "test_deserialize";
+        let directory_manager = DirectoryManager::_new_with_base_path(base_path);
+        directory_manager
+            .create_network_directory(network_id)
+            .unwrap();
+        let network_info_file = directory_manager.network_file_path(network_id);
+        let mut file = File::create(network_info_file).unwrap();
+        file.write_all(network_info_str.as_bytes()).unwrap();
+
+        let graphql = GraphQl::new(directory_manager);
+
+        let endpoint = graphql.get_endpoint("mina-bp-1", network_id).unwrap();
+        assert_eq!(endpoint, "http://localhost:4001/graphql");
+
+        let endpoint = graphql.get_endpoint("mina-bp-2", network_id).unwrap();
+        assert_eq!(endpoint, "http://localhost:4006/graphql");
+
+        let endpoint = graphql.get_endpoint("mina-snark-worker-1", network_id);
+        assert_eq!(endpoint, None);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -291,17 +291,20 @@ fn main() -> Result<()> {
                 }
 
                 if cmd.import_accounts {
-                    info!("Importing accounts for node '{node_id}' in network '{network_id}'.");
+                    warn!("Importing accounts for node '{node_id}' in network '{network_id}'. This can take a moment...");
                     import_all_accounts(&docker, &directory_manager, &node_id, &network_id)?;
                 }
 
                 match docker.compose_start(vec![&container]) {
                     Ok(out) => {
                         if out.status.success() {
-                            let gql = GraphQl::new(directory_manager.clone());
-                            if let Some(gql_ep) = gql.get_endpoint(&node_id, &network_id) {
-                                gql.wait_for_server(&gql_ep)?;
-                                gql.request_filtered_logs(&gql_ep)?;
+                            if cmd.graphql_filtered_logs {
+                                warn!("Waiting for graphql server to be operational so I can request filtered logs. This can take a moment...");
+                                let gql = GraphQl::new(directory_manager.clone());
+                                if let Some(gql_ep) = gql.get_endpoint(&node_id, &network_id) {
+                                    gql.wait_for_server(&gql_ep)?;
+                                    gql.request_filtered_logs(&gql_ep)?;
+                                }
                             }
 
                             if cmd.node_args.raw_output {

--- a/src/main.rs
+++ b/src/main.rs
@@ -298,14 +298,21 @@ fn main() -> Result<()> {
                                 .iter()
                                 .find(|node| node.service_name == node_id)
                                 .unwrap()
-                                .client_port
-                                .unwrap();
-                            wait_for_daemon(&docker, &node_id, &network_id, client_port)?;
-                            request_filtered_logs_via_graphql(
-                                &directory_manager,
-                                &node_id,
-                                &network_id,
-                            )?;
+                                .client_port;
+                            if client_port.is_some() {
+                                wait_for_daemon(
+                                    &docker,
+                                    &node_id,
+                                    &network_id,
+                                    client_port.unwrap(),
+                                )?;
+                                request_filtered_logs_via_graphql(
+                                    &directory_manager,
+                                    &node_id,
+                                    &network_id,
+                                )?;
+                            }
+
                             if cmd.node_args.raw_output {
                                 println!(
                                     "Node '{node_id}' on network '{network_id}' \
@@ -695,7 +702,19 @@ fn request_filtered_logs_via_graphql(
 
     // Define the query and the request payload
     let query = r#"{
-        "query": "mutation MyMutation { startFilteredLog(filter: []) }"
+        "query": "mutation MyMutation { startFilteredLog(filter: [\"21ccae8c619bc2666474085272d5fe1d\", 
+                                                                  \"ef1182dc30f3e0aa9f6bf11c0ab90ba6\",
+                                                                  \"64e2d3e86c37c09b15efdaf7470ce879\",
+                                                                  \"db06cb5030f39e86e84b30d033f3bc5c\", 
+                                                                  \"60076de624bf0c5fc0843b875001cf84\", 
+                                                                  \"27953f46376ba8abc0c61400e2c38f8b\", 
+                                                                  \"b4b5f5b1d1a0c457cbd13a35d1c8b57b\", 
+                                                                  \"0fc65f5594c5e9ee0b6f0ddde747c758\", 
+                                                                  \"b5a89d6d616a35fb6f73d1eaad6b2dbd\", 
+                                                                  \"1c4150aa7058a3058c4d20ae90ff7ec3\", 
+                                                                  \"f7254e63ad51092a0bd3078580ef9ce3\", 
+                                                                  \"74a81f1e2f8d548e4550faa136c68160\", 
+                                                                  \"30fe76cee159ea215fc05549e861501e\"]) }"
     }"#;
 
     // Create a client


### PR DESCRIPTION
Requesting filtered logs on `node start` when additional flag is used `--graphql-filtered-logs`