### PR TITLE
Introduce MINIMINA_HOME env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ $ tree -p ~/.minimina/default/
     ├── [-rw-------]  mina-snark-worker-1
     └── [-rw-r--r--]  mina-snark-worker-1.pub
 ```
+ :information_source: By default minimina stores files in `$HOME\.minimina`. You can set env variable `$MINIMINA_HOME` if you want it to store files in `$MINIMINA_HOME\.minimina`.
 
 The default network can be started, stopped, and deleted
 

--- a/src/directory_manager.rs
+++ b/src/directory_manager.rs
@@ -13,7 +13,7 @@
 use crate::genesis_ledger::GENESIS_LEDGER_JSON;
 use crate::output;
 use crate::service::ServiceConfig;
-use dirs::home_dir;
+// use dirs::home_dir;
 use log::info;
 use std::os::unix::fs::PermissionsExt;
 use std::{
@@ -33,7 +33,7 @@ pub struct DirectoryManager {
 
 impl DirectoryManager {
     pub fn new() -> Self {
-        let mut base_path = home_dir().expect("Home directory not found");
+        let mut base_path = PathBuf::from("./");
         base_path.push(".minimina");
         DirectoryManager {
             base_path,

--- a/src/directory_manager.rs
+++ b/src/directory_manager.rs
@@ -13,8 +13,9 @@
 use crate::genesis_ledger::GENESIS_LEDGER_JSON;
 use crate::output;
 use crate::service::ServiceConfig;
-// use dirs::home_dir;
+use dirs::home_dir;
 use log::info;
+use std::env;
 use std::os::unix::fs::PermissionsExt;
 use std::{
     fs,
@@ -24,6 +25,7 @@ use std::{
 
 pub const NETWORK_KEYPAIRS: &str = "network-keypairs";
 const LIBP2P_KEYPAIRS: &str = "libp2p-keypairs";
+const MINIMINA_HOME: &str = "MINIMINA_HOME";
 
 #[derive(Clone)]
 pub struct DirectoryManager {
@@ -33,7 +35,11 @@ pub struct DirectoryManager {
 
 impl DirectoryManager {
     pub fn new() -> Self {
-        let mut base_path = PathBuf::from("./");
+        let mut base_path = if let Ok(env_path) = env::var(MINIMINA_HOME) {
+            PathBuf::from(env_path)
+        } else {
+            home_dir().expect("Home directory not found")
+        };
         base_path.push(".minimina");
         DirectoryManager {
             base_path,

--- a/src/main.rs
+++ b/src/main.rs
@@ -855,7 +855,7 @@ fn generate_default_topology(
         service_name: snark_worker_1_name.to_string(),
         docker_image: Some(docker_image.into()),
         snark_coordinator_port: Some(7000),
-        snark_worker_proof_level: Some("none".into()),
+        snark_worker_proof_level: Some("full".into()),
         snark_coordinator_host: Some(snark_coordinator.service_name.clone()),
         ..Default::default()
     };


### PR DESCRIPTION
Add possibility to set `MINIMINA_HOME` which overrides default base path (`~`) where minimina stores files.