### PR TITLE
Import accounts change

### DIFF
--- a/src/docker/manager.rs
+++ b/src/docker/manager.rs
@@ -282,9 +282,11 @@ impl DockerManager {
         let service = format!("{node_id}-{network_id}");
         let privkey_path = format!("/local-network/{NETWORK_KEYPAIRS}/{account_file}");
         let cmd = &[
-            "exec",
-            &service,
+            "run",
+            "--rm",
+            "--entrypoint",
             "mina",
+            &service,
             "accounts",
             "import",
             "--privkey-path",

--- a/src/main.rs
+++ b/src/main.rs
@@ -1117,9 +1117,6 @@ fn import_all_accounts(
     node_id: &str,
     network_id: &str,
 ) -> Result<()> {
-    let container = format!("{node_id}-{network_id}");
-    docker.compose_start(vec![&container])?;
-    container_is_running(docker, &container)?;
     let account_files = directory_manager.get_network_keypair_files(network_id)?;
     for account_file in account_files {
         let out = docker.compose_import_account(node_id, network_id, &account_file);
@@ -1148,6 +1145,5 @@ fn import_all_accounts(
             }
         }
     }
-    docker.compose_stop(vec![&container])?;
     Ok(())
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -114,6 +114,8 @@ impl ServiceConfig {
             "true".to_string(),
             "-log-precomputed-blocks".to_string(),
             "true".to_string(),
+            "-proof-level".to_string(),
+            "full".to_string(),
         ]
     }
 


### PR DESCRIPTION
I've changed how the accounts are imported. Now there is no need to start and stop the container as we use `docker compose run` instead `docker compose exec`. I was hoping it may fix the replayer issue... It does not, but makes `node start --import-accounts` slightly faster...