### PR TITLE
Install minimina action updates

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,7 +52,7 @@ jobs:
           REF_NAME=$(echo ${GITHUB_REF#refs/*/})
         fi
         echo "Extracted reference name: $REF_NAME"
-        echo "::set-output name=ref::${REF_NAME}"
+        echo "ref=$REF_NAME" >> $GITHUB_OUTPUT
 
     - name: 🤌 Get MiniMina from source
       uses: MinaFoundation/install-minimina-action@v1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,7 +66,7 @@ jobs:
           minimina network create
           minimina network start
           minimina network status
-          minimina netowork info
+          minimina network info
           minimina node stop -i mina-bp-1
           minimina node start -i mina-bp-1
           minimina network stop
@@ -79,7 +79,7 @@ jobs:
           minimina network create -n large -t tests/data/large_network/topology.json -g tests/data/large_network/genesis_ledger.json
           minimina network start -n large
           minimina network status -n large
-          minimina netowork info -n large
+          minimina network info -n large
           minimina node stop -n large -i empty_node-1
           minimina node start -n large -i empty_node-1
           minimina network stop -n large

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - name: 📥 Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: ✅ Format
       run: cargo fmt --all -- --check
@@ -38,9 +38,44 @@ jobs:
     - name: 🧪 Test
       run: cargo test --verbose
 
+  integration:
+    runs-on: minafoundation-default-runners
+
+    steps:
+    - name: 🤌 Get MiniMina from source
+      uses: MinaFoundation/install-minimina-action@v1
+      with:
+        # Current commit or branch to use for MiniMina
+        commit_or_branch: ${{ github.sha }}
+
+    - name: 🧪 Test default network
+      run: |
+          minimina network create
+          minimina network start
+          minimina network status
+          minimina netowork info
+          minimina node stop -i mina-bp-1
+          minimina node start -i mina-bp-1
+          minimina network stop
+          minimina network delete
+
+    - name: 🧪 Test network from topology
+      run: |
+          cd minimina
+          minimina network create -n large -t tests/data/large_network/topology.json -g tests/data/large_network/genesis_ledger.json
+          minimina network start -n large
+          minimina network status -n large
+          minimina netowork info -n large
+          minimina node stop -n large -i empty_node-1
+          minimina node start -n large -i empty_node-1
+          minimina network stop -n large
+          minimina network delete -n large
+
   deploy:
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
-    needs: build
+    needs: 
+      - build
+      - integration
     runs-on: minafoundation-default-runners
     environment: package
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,13 +42,26 @@ jobs:
     runs-on: minafoundation-default-runners
 
     steps:
+    - name: 🪄 Extract reference name
+      id: extract_ref
+      shell: bash
+      run: |
+        if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          REF_NAME=${{ github.head_ref }}
+        else
+          REF_NAME=$(echo ${GITHUB_REF#refs/*/})
+        fi
+        echo "Extracted reference name: $REF_NAME"
+        echo "::set-output name=ref::${REF_NAME}"
+
     - name: 🤌 Get MiniMina from source
       uses: MinaFoundation/install-minimina-action@v1
       with:
         # Current commit or branch to use for MiniMina
-        commit_or_branch: ${{ github.sha }}
+        commit_or_branch: ${{ steps.extract_ref.outputs.ref }}
 
     - name: 🧪 Test default network
+      shell: bash
       run: |
           minimina network create
           minimina network start
@@ -60,6 +73,7 @@ jobs:
           minimina network delete
 
     - name: 🧪 Test network from topology
+      shell: bash
       run: |
           cd minimina
           minimina network create -n large -t tests/data/large_network/topology.json -g tests/data/large_network/genesis_ledger.json

--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ For building and testing MiniMina requires Rust compiler and its package manager
 
 ## Getting Started
 
-To set up and use MiniMina, you have a couple of options: building from source or using the provided deb package.
+To set up and use MiniMina, you have a couple of options: 
+ - building from source
+ - using the provided deb package
+
+**Tip:** Integrating MiniMina into your GitHub workflow is straightforward with the [MinaFoundation/install-minimina-action](https://github.com/MinaFoundation/install-minimina-action).
 
 ### Building from Source
 


### PR DESCRIPTION
This PR:
 - references https://github.com/MinaFoundation/install-minimina-action from readme
 - adds basic integration test workflow to the GH action workflow (testing default network and topology based network) utilizing `install-minimina-action` as a way to get minimina to the environment