### PR TITLE
PM-715 - Resource experiments (add RAYON_NUM_THREADS=2 per daemon)

### DIFF
--- a/src/docker/compose.rs
+++ b/src/docker/compose.rs
@@ -71,6 +71,7 @@ struct Service {
 
 pub const CONFIG_DIRECTORY: &str = "config-directory";
 const POSTGRES_DATA: &str = "postgres-data";
+const RAYON_NUM_THREADS: u32 = 2;
 
 impl DockerCompose {
     pub fn generate(configs: &[ServiceConfig], network_path: &Path) -> String {
@@ -308,7 +309,7 @@ impl DockerCompose {
                         None
                     },
                     mina_client_trustlist: "0.0.0.0/0".to_string(),
-                    rayon_num_threads: 4,
+                    rayon_num_threads: RAYON_NUM_THREADS,
                 },
             },
             volumes,

--- a/src/docker/compose.rs
+++ b/src/docker/compose.rs
@@ -44,6 +44,7 @@ struct Environment {
     mina_client_trustlist: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     uptime_privkey_pass: Option<String>,
+    rayon_num_threads: u32,
 }
 
 #[derive(Default, Serialize)]
@@ -307,6 +308,7 @@ impl DockerCompose {
                         None
                     },
                     mina_client_trustlist: "0.0.0.0/0".to_string(),
+                    rayon_num_threads: 4,
                 },
             },
             volumes,
@@ -330,6 +332,7 @@ impl DockerCompose {
         .replace("mina_libp2p_pass", "MINA_LIBP2P_PASS")
         .replace("uptime_privkey_pass", "UPTIME_PRIVKEY_PASS")
         .replace("mina_client_trustlist", "MINA_CLIENT_TRUSTLIST")
+        .replace("rayon_num_threads", "RAYON_NUM_THREADS")
         .replace("null", "")
     }
 


### PR DESCRIPTION
As there were some resource issues when using minimina in GH actions, adding explicitly RAYON_NUM_THREADS=2 per daemon to keep threads under control. Atm, not making this configurable, if it turns out to be needed we can add additional flag to `network create` command.