### PR TITLE
add -main suffix to version when uploading to unstable

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -100,7 +100,14 @@ jobs:
     - name: 📦 Package
       run: | 
           cargo install cargo-deb
-          cargo deb
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+              cargo deb
+          else
+              # add -main suffix to version
+              version=$(grep "^version" Cargo.toml | head -1 | awk -F '"' '{print $2}')
+              modified_version="${version}-main"
+              cargo deb --deb-version="$modified_version"
+          fi
 
     - name: 📤 Upload 
       env:


### PR DESCRIPTION
I've noticed that uploading to unstable with the same version as in stable breaks one of them as the checksums don't agree. To circumvent this, adding "-main" suffix to version when uploading to unstable.